### PR TITLE
Feature/relative path fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,20 @@
-FROM node:10.15.2-slim
+FROM node:12.10-slim
 MAINTAINER Gary Luu "gary.luu@oicr.on.ca"
-RUN apt-get update -yq
+RUN apt update -yq
 # install git
-RUN apt-get install git -yq
+RUN apt install git -yq
 # install dredd
-RUN npm install -g dredd@8.0.3 --unsafe-perm --allow-root
+RUN npm install -g dredd@12.0.7 --unsafe-perm --allow-root
 # install python
-RUN apt-get install python-pip -yq
+RUN apt install python-pip -yq
+# set branch
+ARG BRANCH=develop
 # This apparently forces --no-cache for git cloning and sadly everything after it
-# TODO: Change all feature/flask in this file to the correct branch
-ADD https://api.github.com/repos/ga4gh/tool-registry-validator/compare/develop...HEAD /dev/null
+ADD https://api.github.com/repos/ga4gh/tool-registry-validator/compare/${BRANCH}...HEAD /dev/null
 RUN git clone https://github.com/ga4gh/tool-registry-validator.git
 
 WORKDIR tool-registry-validator
-RUN git checkout develop
+RUN git checkout ${BRANCH}
 RUN pip install -r validator/requirements.txt
 RUN pip install uwsgi -I --no-cache-dir
 WORKDIR validator

--- a/validator/hooks.py
+++ b/validator/hooks.py
@@ -11,7 +11,7 @@ DEFAULT_VERSION_ID = 'version_id_placeholder'
 DEFAULT_ID = 'id_placeholder'
 
 NEW_TYPE = None
-NEW_RELATIVE_PATH = None
+NEW_RELATIVE_PATH = 'Dockerfile'
 NEW_VERSION_ID = None
 NEW_ID = None
 basePath = '/api/ga4gh/v2'
@@ -33,7 +33,7 @@ def add_path_parameter_values(transaction):
         transaction['fullPath'] = transaction['fullPath'].replace(
             DEFAULT_TYPE, NEW_TYPE)
         transaction['fullPath'] = transaction['fullPath'].replace(
-            DEFAULT_RELATIVE_PATH, '%2Fsequenza.cwl')
+            DEFAULT_RELATIVE_PATH, NEW_RELATIVE_PATH)
         transaction['fullPath'] = transaction['fullPath'].replace(
             DEFAULT_ID, NEW_ID)
     else:


### PR DESCRIPTION
Previously the relative path parameter is hardcoded to be `'%2Fsequenza.cwl'` which worked when the tool that was being tested specifically had that file.  The tool that's being tested has now changed (and may also likely change in the future). This determines a new relative path parameter by using the /fiiles endpoint.

Also updated dredd and node