### PR TITLE
Feature/fix badges

### DIFF
--- a/validator/constants.py
+++ b/validator/constants.py
@@ -1,7 +1,7 @@
 SWAGGER = "processed-ga4gh-tool-discovery.yaml"
 GENERATED_SWAGGER = 'GA4GH.swagger.json'
 PREPROCESSED_SWAGGER = 'ga4gh-tool-discovery.yaml'
-EXPECTED_PASSING_TESTS = 11
+EXPECTED_PASSING_TESTS = 10
 GITHUB_BASEURL = 'https://raw.githubusercontent.com/ga4gh/tool-registry-schemas'
 GITHUB_BRANCH = '2.0.0'
 GITHUB_FILE_PATH = 'openapi/ga4gh-tool-discovery.yaml'

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -70,14 +70,14 @@ def _badge_from_output(output):
     :param output: Output from validation
     :return: Badge based on validation output
     """
-    if ' 0 errors' not in output:
+    if '0 errors' not in output:
         badge = cache.get('error')
         if badge is None:
             badge = requests.get(error_badge())
             if badge.status_code == 200:
                 cache.set('error', badge, timeout=BADGE_CACHE_TIMEOUT)
         return badge
-    if ' 0 failing' not in output:
+    if '0 failing' not in output:
         badge = cache.get('failing')
         if badge is None:
             badge = requests.get(failing_badge())
@@ -91,7 +91,7 @@ def _badge_from_output(output):
             if badge.status_code == 200:
                 cache.set('warning', badge, timeout=BADGE_CACHE_TIMEOUT)
         return badge
-    if ' 0 failing, 0 errors' in output:
+    if '0 failing' in output and '0 errors' in output:
         badge = cache.get('passing')
         if badge is None:
             badge = requests.get(passing_badge())


### PR DESCRIPTION
Appears badges have been broken for some time since Dredd reporter was changed to HTML.

Reporter output looks like:
```
<p><strong>Tests completed:</strong> 10 passing,
0 failing,
0 errors,
7 skipped,
17 total.</p>
<p><strong>Tests took:</strong> 7727ms.</p>
```
nowadays